### PR TITLE
Use Windows 11 24H2 color functions, if available

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       name: Install Windows 11 SDK 26100
 
     - name: Configure CMake
-      run: cmake -A x64 -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/install
+      run: cmake -A x64,version=10.0.26100.0 -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/install
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,11 @@ jobs:
     - name: Install marko
       run: python -m pip install marko
 
+    - uses: res2k/setup-winsdk@support-sdk-26100 # TEMPORARY until upstream fbactions/setup-winsdk works w/ 26100
+      with:
+        winsdk-build-version: 26100
+      name: Install Windows 11 SDK 26100
+
     - name: Configure CMake
       run: cmake -A x64 -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/install
 

--- a/common/HDR.cpp
+++ b/common/HDR.cpp
@@ -94,17 +94,7 @@ Status GetWindowsHDRStatus()
 
 static std::optional<Status> SetDisplayHDRStatus(const DISPLAYCONFIG_MODE_INFO& mode, bool enable)
 {
-    DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO getColorInfo = {};
-    getColorInfo.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_ADVANCED_COLOR_INFO;
-    getColorInfo.header.size = sizeof(getColorInfo);
-    getColorInfo.header.adapterId.HighPart = mode.adapterId.HighPart;
-    getColorInfo.header.adapterId.LowPart = mode.adapterId.LowPart;
-    getColorInfo.header.id = mode.id;
-
-    if (DisplayConfigGetDeviceInfo(&getColorInfo.header) != ERROR_SUCCESS)
-        return std::nullopt;
-
-    if (!getColorInfo.advancedColorSupported)
+    if (GetDisplayHDRStatus(mode) == Status::Unsupported)
         return std::nullopt;
 
     // Try SET_HDR_STATE first (available on Windows 11 24H2)

--- a/common/HDR.cpp
+++ b/common/HDR.cpp
@@ -183,20 +183,7 @@ std::vector<Display> GetDisplays()
     ForEachDisplay([&](const DISPLAYCONFIG_MODE_INFO& mode) {
         Display new_disp;
 
-        DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO getColorInfo = {};
-        getColorInfo.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_ADVANCED_COLOR_INFO;
-        getColorInfo.header.size = sizeof(getColorInfo);
-        getColorInfo.header.adapterId.HighPart = mode.adapterId.HighPart;
-        getColorInfo.header.adapterId.LowPart = mode.adapterId.LowPart;
-        getColorInfo.header.id = mode.id;
-
-        if (DisplayConfigGetDeviceInfo(&getColorInfo.header) != ERROR_SUCCESS)
-            return;
-
-        if (getColorInfo.advancedColorSupported)
-            new_disp.status = getColorInfo.advancedColorEnabled ? Status::On : Status::Off;
-        else
-            new_disp.status = Status::Unsupported;
+        new_disp.status = GetDisplayHDRStatus(mode);
 
         DISPLAYCONFIG_TARGET_DEVICE_NAME deviceName = {};
         deviceName.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_NAME;

--- a/common/HDR.cpp
+++ b/common/HDR.cpp
@@ -59,6 +59,7 @@ static Status GetDisplayHDRStatus(const DISPLAYCONFIG_MODE_INFO& mode)
         if (!getColorInfo2.highDynamicRangeSupported)
             return Status::Unsupported;
 
+        // Only DISPLAYCONFIG_ADVANCED_COLOR_MODE_HDR is true HDR.
         return getColorInfo2.activeColorMode == DISPLAYCONFIG_ADVANCED_COLOR_MODE_HDR ? Status::On : Status::Off;
     }
 
@@ -100,7 +101,9 @@ static std::optional<Status> SetDisplayHDRStatus(const DISPLAYCONFIG_MODE_INFO& 
     if (GetDisplayHDRStatus(mode) == Status::Unsupported)
         return std::nullopt;
 
-    // Try SET_HDR_STATE first (available on Windows 11 24H2)
+    /* Try SET_HDR_STATE first, if available (on Windows 11 >= 24H2).
+     * This seems to work better with ACM enabled (in which case "advanced color" is always
+     * enabled and changing it doesn't do much.) */
     DISPLAYCONFIG_SET_HDR_STATE setHdrState = {};
     setHdrState.header.type = DISPLAYCONFIG_DEVICE_INFO_SET_HDR_STATE;
     setHdrState.header.size = sizeof(setHdrState);

--- a/common/HDR.cpp
+++ b/common/HDR.cpp
@@ -14,12 +14,15 @@
 #include <vector>
 
 #include "framework.h"
+#include "WinVerCheck.hpp"
 
 #if !defined(NTDDI_WIN11_GA) || WDK_NTDDI_VERSION < NTDDI_WIN11_GA
 #error Windows SDK too old: Version >= 10.0.26100 required
 #endif
 
 namespace hdr {
+
+static const bool use_win11_24h2_color_functions = IsWindows11_24H2OrGreater();
 
 template<typename F> static void ForEachDisplay(F func)
 {
@@ -51,7 +54,7 @@ static Status GetDisplayHDRStatus(const DISPLAYCONFIG_MODE_INFO& mode)
     getColorInfo2.header.adapterId.HighPart = mode.adapterId.HighPart;
     getColorInfo2.header.adapterId.LowPart = mode.adapterId.LowPart;
     getColorInfo2.header.id = mode.id;
-    if (DisplayConfigGetDeviceInfo(&getColorInfo2.header) == ERROR_SUCCESS)
+    if (use_win11_24h2_color_functions && DisplayConfigGetDeviceInfo(&getColorInfo2.header) == ERROR_SUCCESS)
     {
         if (!getColorInfo2.highDynamicRangeSupported)
             return Status::Unsupported;
@@ -105,7 +108,7 @@ static std::optional<Status> SetDisplayHDRStatus(const DISPLAYCONFIG_MODE_INFO& 
     setHdrState.header.adapterId.LowPart = mode.adapterId.LowPart;
     setHdrState.header.id = mode.id;
     setHdrState.enableHdr = enable;
-    if (DisplayConfigSetDeviceInfo(&setHdrState.header) == ERROR_SUCCESS)
+    if (use_win11_24h2_color_functions && DisplayConfigSetDeviceInfo(&setHdrState.header) == ERROR_SUCCESS)
         return GetDisplayHDRStatus(mode);
 
     DISPLAYCONFIG_SET_ADVANCED_COLOR_STATE setColorState = {};

--- a/common/WinVerCheck.hpp
+++ b/common/WinVerCheck.hpp
@@ -54,4 +54,9 @@ static bool IsWindows10_1903OrGreater ()
     return IsWindows10BuildOrGreater(18362);
 }
 
+static bool IsWindows11_24H2OrGreater ()
+{
+    return IsWindows10BuildOrGreater(26100);
+}
+
 #endif // WINVERCHECK_HPP_


### PR DESCRIPTION
To address behavior reported in #13.