### PR TITLE
Add toggle subcommand to HDRCmd to switch between on or off

### DIFF
--- a/HDRCmd/CMakeLists.txt
+++ b/HDRCmd/CMakeLists.txt
@@ -13,6 +13,8 @@ target_sources(HDRCmd PRIVATE
                "subcommand/Enable.cpp"
                "subcommand/Status.hpp"
                "subcommand/Status.cpp"
+               "subcommand/Toggle.hpp"
+               "subcommand/Toggle.cpp"
                )
 target_compile_definitions(HDRCmd PRIVATE UNICODE _UNICODE)
 target_include_directories(HDRCmd PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/generated")

--- a/HDRCmd/HDRCmd.cpp
+++ b/HDRCmd/HDRCmd.cpp
@@ -21,6 +21,7 @@
 #include "subcommand/Disable.hpp"
 #include "subcommand/Enable.hpp"
 #include "subcommand/Status.hpp"
+#include "subcommand/Toggle.hpp"
 #include "version.h"
 #include "WinVerCheck.hpp"
 
@@ -48,6 +49,7 @@ int wmain(int argc, const wchar_t* const argv[])
     subcommand::Status::add(app);
     subcommand::Enable::add(app);
     subcommand::Disable::add(app);
+    subcommand::Toggle::add(app);
 
     CLI11_PARSE(app, argc, argv);
     const auto* subcmd = app.get_subcommands()[0];

--- a/HDRCmd/subcommand/Toggle.cpp
+++ b/HDRCmd/subcommand/Toggle.cpp
@@ -27,6 +27,8 @@ Toggle::Toggle(CLI::App* parent) : Base("Toggle HDR on/off", "toggle", parent) {
 int Toggle::run() const
 {
     auto status = hdr::GetWindowsHDRStatus();
+    if (status == hdr::Status::Unsupported)
+        return -1;
     auto result = hdr::SetWindowsHDRStatus(status != hdr::Status::On);
     if (!result)
         return -1;

--- a/HDRCmd/subcommand/Toggle.cpp
+++ b/HDRCmd/subcommand/Toggle.cpp
@@ -1,6 +1,6 @@
 /*
     HDRCmd - enable/disable "Use HDR" from command line
-    Copyright (C) 2024 Frank Richter
+    Copyright (C) 2026 Frank Richter, flameshikari
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/HDRCmd/subcommand/Toggle.cpp
+++ b/HDRCmd/subcommand/Toggle.cpp
@@ -1,0 +1,41 @@
+/*
+    HDRCmd - enable/disable "Use HDR" from command line
+    Copyright (C) 2024 Frank Richter
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "Toggle.hpp"
+
+#include "HDR.h"
+
+namespace subcommand {
+
+Toggle::Toggle(CLI::App* parent) : Base("Toggle HDR on/off", "toggle", parent) { }
+
+int Toggle::run() const
+{
+    auto status = hdr::GetWindowsHDRStatus();
+    auto result = hdr::SetWindowsHDRStatus(status != hdr::Status::On);
+    if (!result)
+        return -1;
+    return *result != status ? 0 : 1;
+}
+
+CLI::App* Toggle::add(CLI::App& app)
+{
+    return app.add_subcommand(std::shared_ptr<Toggle>(new Toggle(&app)));
+}
+
+} // namespace subcommand

--- a/HDRCmd/subcommand/Toggle.hpp
+++ b/HDRCmd/subcommand/Toggle.hpp
@@ -1,6 +1,6 @@
 /*
     HDRCmd - enable/disable "Use HDR" from command line
-    Copyright (C) 2024 Frank Richter
+    Copyright (C) 2026 Frank Richter, flameshikari
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/HDRCmd/subcommand/Toggle.hpp
+++ b/HDRCmd/subcommand/Toggle.hpp
@@ -1,0 +1,38 @@
+/*
+    HDRCmd - enable/disable "Use HDR" from command line
+    Copyright (C) 2024 Frank Richter
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef SUBCOMMAND_TOGGLE_HPP_
+#define SUBCOMMAND_TOGGLE_HPP_
+
+#include "Base.hpp"
+
+namespace subcommand {
+class Toggle : public Base
+{
+protected:
+    Toggle(CLI::App* parent);
+
+public:
+    int run() const override;
+
+    static CLI::App* add(CLI::App& app);
+};
+
+} // namespace subcommand
+
+#endif // SUBCOMMAND_TOGGLE_HPP_

--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ Turns HDR off on all supported displays.
 
 Does not accept any options.
 
+## `toggle` command
+Toggles HDR on all supported displays.
+
+Does not accept any options.
+
 ## `status` command
 Prints the current HDR status to the console. Has a special mode that returns an exit code depending on the status.
 


### PR DESCRIPTION
Hello!

Thanks for the utility. It's a lifesaver when Xbox Game Bar is not installed (it was only used for Win+Alt+B shortcut to toggle HDR, lol).

I recently decided to assign a keyboard shortcut to toggle HDR using HDRCmd, but there's no toggle feature. Yes I could write an if-else script, but I thought I'd try embedding this feature into your utility to make it a little more convenient. I hope this won't be unnecessary.

Also updated gh-pages documentation in #43 